### PR TITLE
changes from 6-23 worksesssion

### DIFF
--- a/src/main/java/org/carlmontrobotics/commands/IntakeNEO.java
+++ b/src/main/java/org/carlmontrobotics/commands/IntakeNEO.java
@@ -11,11 +11,16 @@ import edu.wpi.first.wpilibj2.command.Command;
 public class IntakeNEO extends Command {
   // intake until sees game peice or 4sec has passed
   private final IntakeShooter intake;
+  private int index = 0;
+  private double increaseSpeed = .01;
+  private double initSpeed = .5;
+  private double slowSpeed = .1;
 
   public IntakeNEO(IntakeShooter intake) {
     addRequirements(this.intake = intake);
-    SmartDashboard.putNumber("Initial intake speed", .5);
-    SmartDashboard.putNumber("Slow intake speed", .1);
+    SmartDashboard.putNumber("Initial intake speed", initSpeed);
+    SmartDashboard.putNumber("Slow intake speed", slowSpeed);
+    SmartDashboard.putNumber("Increase speed", increaseSpeed);
   }
 
   @Override
@@ -24,22 +29,28 @@ public class IntakeNEO extends Command {
     // if (intake.intakeDetectsNote()) {
     // return;
     // }
-
-    intake.motorSetIntake(SmartDashboard.getNumber("Initial intake speed", 0)); // Fast intake speed
+    initSpeed = SmartDashboard.getNumber("Initial intake speed", 0);
+    intake.motorSetIntake(initSpeed); // Fast intake speed
                                                                                 // for initial
                                                                                 // intake
     intake.resetCurrentLimit();
+    index = 0;
   }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
     // Intake Led
+    increaseSpeed = SmartDashboard.getNumber("Increase speed", 0);
+    slowSpeed = SmartDashboard.getNumber("Slow intake speed", 0);
     if ((intake.intakeDetectsNote())) {
-      intake.motorSetIntake(SmartDashboard.getNumber("Slow intake speed", 0)); // Slower intake
+      double intakeSpeed = slowSpeed + index * increaseSpeed;
+      SmartDashboard.putNumber("Intake-current-speed", intakeSpeed);
+      intake.motorSetIntake(intakeSpeed); // Slower intake
                                                                                // speed triggered
                                                                                // after intake ds
                                                                                // sees note
+      ++index;
     }
   }
 

--- a/src/main/java/org/carlmontrobotics/subsystems/Drivetrain.java
+++ b/src/main/java/org/carlmontrobotics/subsystems/Drivetrain.java
@@ -208,7 +208,6 @@ public class Drivetrain extends SubsystemBase {
             }
 
             SmartDashboard.putData("Field", field);
-            SmartDashboard.putData(this);
 
             // for(CANSparkMax driveMotor : driveMotors)
             // driveMotor.setSmartCurrentLimit(80);
@@ -228,6 +227,8 @@ public class Drivetrain extends SubsystemBase {
         //                 SmartDashboard.putNumber("chassis speeds y", 0);
 
         //                             SmartDashboard.putNumber("chassis speeds theta", 0);
+        SmartDashboard.putData(this);
+
     }
 
     @Override

--- a/src/main/java/org/carlmontrobotics/subsystems/Limelight.java
+++ b/src/main/java/org/carlmontrobotics/subsystems/Limelight.java
@@ -48,7 +48,7 @@ public class Limelight extends SubsystemBase {
     SmartDashboard.putBoolean("see note", LimelightHelpers.getTV(INTAKE_LL_NAME));
     SmartDashboard.putNumber("distance to note", getDistanceToNoteMeters());
     SmartDashboard.putNumber("intake tx", LimelightHelpers.getTX(INTAKE_LL_NAME));
-    SmartDashboard.putNumber("rotation to align", getRotateAngleRad());
+    SmartDashboard.putNumber("rotation to align", getRotateAngleRadMT2());
 
     // shooter limelight testing
     SmartDashboard.putNumber("distance to speaker (meters)", getDistanceToSpeakerMetersMT2());


### PR DESCRIPTION
Changes:
1. The bug mentioned in Issue #80 is caused by using `SmartDashboard.putData(this);` before odometry is initialized. That is fixed now.
2. The speed used to slowly move the note until outtake distance sensor detection varies significantly depending on whether the note is touching the side plates or not. This is resolved by ramping up the speed when the distance sensor doesn't detect the note. Current values work but can be tuned better so I left the SmartDashboard values in there. Sometimes, the note is really against the side plate such that the speed ramps all the way up to near max speed until the note actually budges and the intake can't be stopped in time (maybe PID + FF can make it faster but IMO other stuff more important to test).

Upcoming Changes (being worked on by @stwiggy):
`Drivetrain.java` uses `SwerveDriveOdometry` while `Limelight.java` has its own `SwervePoseEstimator` as odometry. We plan to combine the two into `Drivetrain.java` which should hopefully fix bugs with the values output by the PoseEstimator. The main issue with those two being separate other than the potential confusion is that the initial pose of the robot is not passed to the `SwervePoseEstimator` and it be easier for both to be set properly if both odometries were just combined into one.
With that mentioned, we will also add functionality to set the pose for testing odometry with limelight.